### PR TITLE
Add Authorization header

### DIFF
--- a/grafannotate/annotation.py
+++ b/grafannotate/annotation.py
@@ -67,7 +67,7 @@ class Annotation:
             raise NotImplementedError('Scheme %s not recognised in uri %s' %
                                       (url_parts.scheme, url))
 
-    def send_to_web(self, url_parts):
+    def send_to_web(self, url_parts, api_key):
         """
         POST event to an endpoint in Grafana Annotations API format
         """

--- a/grafannotate/annotation.py
+++ b/grafannotate/annotation.py
@@ -77,7 +77,7 @@ class Annotation:
         auth_tuple = None
         req_headers = {}
         if api_key is not None:
-            req_headers['Authorisation'] = "Bearer %s" % api_key
+            req_headers['Authorization'] = "Bearer %s" % api_key
 
         if url_parts.username and url_parts.password:
             auth_tuple = (url_parts.username, url_parts.password)

--- a/grafannotate/cli.py
+++ b/grafannotate/cli.py
@@ -12,6 +12,8 @@ CURRENT_TIMESTAMP = int(time.time())
 @click.option('-u', '--uri', 'annotate_uri',
               default='http://localhost:3000/api/annotations',
               help='URI to send annotation to. Default: "http://localhost:3000/api/annotations".')
+@click.option('-k', '--api-key', 'api_key', default=None,
+              help='Grafana API key to pass in Authorisation header')
 @click.option('-T', '--title', 'title', default='event', help='Event title. Default: "event".')
 @click.option('-t', '--tag', 'tags', multiple=True, help='Event tags (can be used multiple times).')
 @click.option('-d', '--description', 'description', help='Event description body. Optional.')
@@ -20,7 +22,7 @@ CURRENT_TIMESTAMP = int(time.time())
 @click.option('-e', '--end', 'end_time', default=CURRENT_TIMESTAMP,
               help='End timestamp (unix secs). Optional.')
 @click.option('--debug/--no-debug', default=False)
-def main(annotate_uri, title, tags, description, start_time, end_time, debug):
+def main(annotate_uri, api_key, title, tags, description, start_time, end_time, debug):
     """
     Send Grafana annotations to various endpoints
     """
@@ -39,7 +41,7 @@ def main(annotate_uri, title, tags, description, start_time, end_time, debug):
                 description = ""
 
         this_annotation = Annotation(title, tags, description, start_time, end_time)
-        result = this_annotation.send(annotate_uri)
+        result = this_annotation.send(annotate_uri, api_key)
 
         if result['event_data']:
             logging.debug(result['event_data'])

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -107,7 +107,7 @@ def test_annotation_send_to_influxdb(mock_influxdbclient):
     url = "influx://user:pass@localhost"
     test_annotation = Annotation('event', ['test'], 'testing')
     mock_influxdbclient.write_points.return_value = True
-    assert test_annotation.send(url) == {
+    assert test_annotation.send(url, None) == {
         'event_data': [{
             'fields': {
                 'tags': 'test',

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -81,6 +81,26 @@ def test_annotation_send_to_web():
             'message': 'Annotation added'
         }
 
+def test_annotation_send_to_web_with_api_key():
+    url = "http://localhost:3000/api/annotations"
+    with requests_mock.Mocker() as m:
+        m.register_uri(
+            requests_mock.POST,
+            url,
+            status_code=200,
+            json={'message': 'Annotation added'}
+        )
+        test_annotation = Annotation('event', ['test'], 'testing', 1559332960, 1559332970)
+        assert test_annotation.send(url, 'aTestKey') == {
+            'event_data': {
+                'isRegion': True,
+                'tags': ['test'],
+                'text': '<b>event</b>\n\ntesting',
+                'time': 1559332960000,
+                'timeEnd': 1559332970000
+            },
+            'message': 'Annotation added'
+        }
 
 def test_annotation_error_sending_to_web():
     url = "http://localhost:3000/api/annotations"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -57,7 +57,7 @@ def test_annotation_fail_to_send_to_web():
     url = "http://user:pass@localhost"
     test_annotation = Annotation('event', ['test'], 'testing')
     with pytest.raises(Exception, match='NewConnectionError'):
-        test_annotation.send(url)
+        test_annotation.send(url, None)
 
 
 def test_annotation_send_to_web():
@@ -70,7 +70,7 @@ def test_annotation_send_to_web():
             json={'message': 'Annotation added'}
         )
         test_annotation = Annotation('event', ['test'], 'testing', 1559332960, 1559332970)
-        assert test_annotation.send(url) == {
+        assert test_annotation.send(url, None) == {
             'event_data': {
                 'isRegion': True,
                 'tags': ['test'],
@@ -92,14 +92,14 @@ def test_annotation_error_sending_to_web():
         )
         test_annotation = Annotation('event', ['test'], 'testing', 1559332960, 1559332960)
         with pytest.raises(Exception, match='Received 400 response, sending event failed'):
-            test_annotation.send(url)
+            test_annotation.send(url, None)
 
 
 def test_annotation_fail_to_send_to_influxdb():
     url = "influx://user:pass@localhost"
     test_annotation = Annotation('event', ['test'], 'testing')
     with pytest.raises(Exception, match='Failed to establish a new connection'):
-        test_annotation.send(url)
+        test_annotation.send(url, None)
 
 
 @mock.patch('grafannotate.annotation.InfluxDBClient')
@@ -124,4 +124,4 @@ def test_annotation_send_bad_url():
     url = "s3://user:pass@localhost"
     test_annotation = Annotation('event', ['test'], 'testing')
     with pytest.raises(NotImplementedError, match='Scheme s3 not recognised'):
-        test_annotation.send(url)
+        test_annotation.send(url, None)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -81,17 +81,20 @@ def test_annotation_send_to_web():
             'message': 'Annotation added'
         }
 
+
 def test_annotation_send_to_web_with_api_key():
     url = "http://localhost:3000/api/annotations"
+    api_key ="307c1ac4-4e7c-4eb4-a56f-3547eeff0e4b"
     with requests_mock.Mocker() as m:
         m.register_uri(
             requests_mock.POST,
             url,
+            request_headers={'Authorization': "Bearer %s" % api_key},
             status_code=200,
             json={'message': 'Annotation added'}
         )
         test_annotation = Annotation('event', ['test'], 'testing', 1559332960, 1559332970)
-        assert test_annotation.send(url, 'aTestKey') == {
+        assert test_annotation.send(url, api_key) == {
             'event_data': {
                 'isRegion': True,
                 'tags': ['test'],
@@ -101,6 +104,7 @@ def test_annotation_send_to_web_with_api_key():
             },
             'message': 'Annotation added'
         }
+
 
 def test_annotation_error_sending_to_web():
     url = "http://localhost:3000/api/annotations"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -84,7 +84,7 @@ def test_annotation_send_to_web():
 
 def test_annotation_send_to_web_with_api_key():
     url = "http://localhost:3000/api/annotations"
-    api_key ="307c1ac4-4e7c-4eb4-a56f-3547eeff0e4b"
+    api_key = "307c1ac4-4e7c-4eb4-a56f-3547eeff0e4b"
     with requests_mock.Mocker() as m:
         m.register_uri(
             requests_mock.POST,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,12 @@ def test_cli_with_user_pass(runner, caplog):
     assert 'NewConnectionError' in caplog.text
 
 
+def test_cli_with_api_key(runner, caplog):
+    result = runner.invoke(cli.main, ['--tag', 'event', '--uri', 'http://localhost', '--api-key', 'aTestKey'])
+    assert result.exit_code == 0
+    assert 'NewConnectionError' in caplog.text
+
+
 def test_cli_with_end_time(runner, caplog):
     result = runner.invoke(cli.main, ['--tag', 'event', '--end', CURRENT_TIMESTAMP + 600])
     assert result.exit_code == 0


### PR DESCRIPTION
This PR adds an auth header if one is passed to the Annotation.

This only passes through to "web" requests (Grafana) until I figure out if the influxDBClient supports passing bearer tokens through.

Closes: #1 